### PR TITLE
:sparkles: 为msctl upgrade追加指定离线包升级支持

### DIFF
--- a/msctl
+++ b/msctl
@@ -3,7 +3,7 @@ action=$1
 target=$2
 args=$@
 
-MS_BASE=/opt/
+MS_BASE=/opt
 COMPOSE_FILES=$(cat ${MS_BASE}/metersphere/compose_files)
 export COMPOSE_HTTP_TIMEOUT=180
 
@@ -21,51 +21,80 @@ function usage() {
    echo "  restart   重启 MeterSphere 服务"
    echo "  reload    重新加载 MeterSphere 服务"
    echo "  upgrade   升级 MeterSphere 至最新版本"
+   echo "  upgrade [RELEASE]  根据版本号搜索离线包，升级 MeterSphere 至对应版本"
    echo "  uninstall 卸载 MeterSphere 服务"
    echo "  version   查看 MeterSphere 版本信息"
 }
 
 function status() {
    echo
-   cd ${MS_BASE}/metersphere; docker-compose ${COMPOSE_FILES} ps
+   cd ${MS_BASE}/metersphere
+   docker-compose ${COMPOSE_FILES} ps
 }
 function start() {
    echo
-   cd ${MS_BASE}/metersphere; docker-compose ${COMPOSE_FILES} start ${target}
+   cd ${MS_BASE}/metersphere
+   docker-compose ${COMPOSE_FILES} start ${target}
 }
 function stop() {
    echo
-   cd ${MS_BASE}/metersphere; docker-compose ${COMPOSE_FILES} stop ${target}
+   cd ${MS_BASE}/metersphere
+   docker-compose ${COMPOSE_FILES} stop ${target}
 }
 function restart() {
    echo
-   cd ${MS_BASE}/metersphere; docker-compose ${COMPOSE_FILES} restart ${target}
+   cd ${MS_BASE}/metersphere
+   docker-compose ${COMPOSE_FILES} restart ${target}
 }
 function reload() {
    echo
-   cd ${MS_BASE}/metersphere; docker-compose ${COMPOSE_FILES} up -d
+   cd ${MS_BASE}/metersphere
+   docker-compose ${COMPOSE_FILES} up -d
 }
 function uninstall() {
    echo
-   cd ${MS_BASE}/metersphere; docker-compose ${COMPOSE_FILES} down ${target}
+   cd ${MS_BASE}/metersphere
+   docker-compose ${COMPOSE_FILES} down ${target}
 }
 function version() {
    echo
    cat ${MS_BASE}/metersphere/version
 }
 function upgrade() {
-   os=`uname -a`
-   if [[ $os =~ 'Darwin' ]];then
-      MSVERSION=$(curl -s https://github.com/metersphere/metersphere/releases/latest |grep -Eo 'v[0-9]+.[0-9]+.[0-9]+')
+   if [ -z "$target" ]; then
+      os=$(uname -a)
+      if [[ $os =~ 'Darwin' ]]; then
+         MSVERSION=$(curl -m 10 -s https://github.com/metersphere/metersphere/releases/latest | grep -Eo 'v[0-9]+.[0-9]+.[0-9]+')
+      else
+         MSVERSION=$(curl -m 10 -s https://github.com/metersphere/metersphere/releases/latest/download 2>&1 | grep -Po 'v[0-9]+\.[0-9]+\.[0-9]+.*(?=")')
+      fi
+      if [ $? -ne 0 ]; then
+         echo -e "\e[31m获取最新版本信息失败:连接github超时！\e[0m"
+         return 2
+      fi
+      echo -e "\e[32m 检测到github最新版本为v\e[1;33m${MSVERSION}\e[0;32m 即将执行在线升级...\e[0m"
+      sleep 5s
+      wget -nv -T 60 -t 1 --no-check-certificate https://github.com/metersphere/metersphere/releases/latest/download/metersphere-release-${MSVERSION}.tar.gz -O /tmp/metersphere-release-${MSVERSION}.tar.gz
+      if [ $? -ne 0 ]; then
+         echo -e "\e[31m升级失败:连接github超时！\n可手动下载升级包，然后执行\e[1;33m msctl upgrade ${MSVERSION} \e[0;31m离线升级\e[0m"
+         return 2
+      fi
+
    else
-      MSVERSION=$(curl -s https://github.com/metersphere/metersphere/releases/latest/download 2>&1 | grep -Po 'v[0-9]+\.[0-9]+\.[0-9]+.*(?=")')
+      MSVERSION=${target}
+      echo -e "\e[32m通过离线包升级到\e[1;33m${MSVERSION}\e[0m"
    fi
 
-   wget --no-check-certificate https://github.com/metersphere/metersphere/releases/latest/download/metersphere-release-${MSVERSION}.tar.gz -O /tmp/metersphere-release-${MSVERSION}.tar.gz
-   cd /tmp;tar zxvf metersphere-release-${MSVERSION}.tar.gz
-   cd metersphere-release-${MSVERSION}
+   if [ ! -f "/tmp/metersphere-release-${MSVERSION}.tar.gz" ]; then
+      echo -e "\e[31m未找到离线升级包\e[1;33m/tmp/metersphere-release-${MSVERSION}.tar.gz\e[31m，请检查！\e[0m"
+      echo -e "参考下载地址：\e[4;7mwget -T60 -t1 --no-check-certificate https://github.com/metersphere/metersphere/releases/download/${MSVERSION}/metersphere-release-${MSVERSION}.tar.gz -O /tmp/metersphere-release-${MSVERSION}.tar.gz\e[0m"
+      return 2
+   fi
 
-   cat ${MS_BASE}/metersphere/.env >> install.conf
+   cd /tmp
+   tar zxvf metersphere-release-${MSVERSION}.tar.gz
+   cd metersphere-release-${MSVERSION}
+   cat ${MS_BASE}/metersphere/.env >>install.conf
    sed -i -e "s#MS_TAG=.*#MS_TAG=${MSVERSION}#g" install.conf
    sed -i -e "s#MS_PREFIX=.*#MS_PREFIX=registry.cn-qingdao.aliyuncs.com\/metersphere#g" install.conf
    /bin/bash install.sh
@@ -73,39 +102,40 @@ function upgrade() {
 }
 
 function main() {
-    case "${action}" in
-      status)
-         status
-         ;;
-      start)
-         start
-         ;;
-      stop)
-         stop
-         ;;
-      restart)
-         restart
-         ;;
-      reload)
-         reload
-         ;;
-      upgrade)
-         upgrade
-         ;;
-      uninstall)
-         uninstall
-         ;;
-      version)
-         version
-         ;;
-      help)
-         usage
-         ;;
-      --help)
-         usage
-         ;;
-      *)
-         echo "不支持的参数，请使用 help 或 --help 参数获取帮助"
-    esac
+   case "${action}" in
+   status)
+      status
+      ;;
+   start)
+      start
+      ;;
+   stop)
+      stop
+      ;;
+   restart)
+      restart
+      ;;
+   reload)
+      reload
+      ;;
+   upgrade)
+      upgrade
+      ;;
+   uninstall)
+      uninstall
+      ;;
+   version)
+      version
+      ;;
+   help)
+      usage
+      ;;
+   --help)
+      usage
+      ;;
+   *)
+      echo "不支持的参数，请使用 help 或 --help 参数获取帮助"
+      ;;
+   esac
 }
 main


### PR DESCRIPTION
## 为upgrade选项支持添加release作为参数

用途：对于国内github抽风的情况，可以先在本机通过gitee或者代理下载好release的tar.gz，手动放到服务器/tmp/目录下

执行`msctl upgrade v1.9.2`  会跳过下载步骤，直接根据/tmp/metersphere-release-v1.9.2.tar.gz更新
执行时各类效果如图


![image](https://user-images.githubusercontent.com/7498123/118795372-18465100-b8cd-11eb-8c74-df7ca33f7ef3.png)

