### PR TITLE
fix: 快速安装脚本通过管道符执行，read命令读取用户输入被跳过问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ if [[ ${__current_version} =~ "lts" ]];then
 else
    if [[ $(cat ${__current_dir}/metersphere/version) =~ "lts" ]];then
       log "\e[31m从非LTS版本升级到LTS版本后，后续将只能升级新的LTS版本，无法再自动升级到非LTS版本\e[0m"
-      read -p "是否确认升级? [n/y]" __choice
+      read -p "是否确认升级? [n/y]" __choice </dev/tty
       case "$__choice" in
          y|Y) echo "继续安装...";;
          n|N) echo "退出安装..."&exit;;


### PR DESCRIPTION
当通过一键安装脚本进行安装时，由于使用了管道符执行脚本，read命令不能正常接收用户输入，导致该交互被跳过，不能正常执行安装脚本。
```
curl -sSL https://github.com/metersphere/metersphere/releases/latest/download/quick_start.sh | bash
````
![d013c110-7681-4290-a7f3-576326e348de](https://user-images.githubusercontent.com/27671436/169776017-9faa85a1-ea3f-438a-b8ef-9098063bd4a6.png)
